### PR TITLE
Add animated battle screen UI

### DIFF
--- a/web/game.js
+++ b/web/game.js
@@ -1,0 +1,175 @@
+const heroes = [
+  {name: 'Warrior', emoji: '🛡️', hp: 30, maxHp: 30, attack: [4,8]},
+  {name: 'Mage', emoji: '🪄', hp: 20, maxHp: 20, attack: [5,10]}
+];
+const monsters = [
+  {name: 'Goblin', emoji: '👺', hp: 15, maxHp: 15, attack: [3,6]},
+  {name: 'Orc', emoji: '🪓', hp: 25, maxHp: 25, attack: [2,7]}
+];
+
+let speed = 1;
+let running = true;
+let round = 1;
+
+const heroesDiv = document.getElementById('heroes');
+const monstersDiv = document.getElementById('monsters');
+const heroPanel = document.getElementById('hero-panel');
+const monsterPanel = document.getElementById('monster-panel');
+const logDiv = document.getElementById('log');
+const statusDiv = document.getElementById('status');
+const effectsSvg = document.getElementById('effects');
+
+document.getElementById('play-pause').onclick = () => {
+  running = !running;
+  document.getElementById('play-pause').textContent = running ? 'Pause' : 'Play';
+};
+document.getElementById('restart').onclick = () => location.reload();
+document.getElementById('speed').oninput = e => {
+  speed = parseFloat(e.target.value);
+};
+
+function createCharElem(c) {
+  const div = document.createElement('div');
+  div.className = 'character';
+  const icon = document.createElement('span');
+  icon.className = 'icon';
+  icon.textContent = c.emoji;
+  div.appendChild(icon);
+  const hpBar = document.createElement('div');
+  hpBar.className = 'hp-bar';
+  const inner = document.createElement('div');
+  inner.className = 'hp-bar-inner';
+  hpBar.appendChild(inner);
+  div.appendChild(hpBar);
+  const label = document.createElement('div');
+  label.className = 'hp-label';
+  div.appendChild(label);
+  c.dom = {div, hpBar: inner, label};
+  updateChar(c);
+  return div;
+}
+
+function updateChar(c) {
+  c.dom.hpBar.style.width = (c.hp / c.maxHp * 100) + '%';
+  c.dom.label.textContent = `${c.hp}/${c.maxHp}`;
+}
+
+function updatePanels() {
+  heroPanel.textContent = heroes.map(h => `${h.name}: ${h.hp}/${h.maxHp}`).join('\n');
+  monsterPanel.textContent = monsters.map(m => `${m.name}: ${m.hp}/${m.maxHp}`).join('\n');
+}
+
+function log(msg) {
+  const entry = document.createElement('div');
+  entry.textContent = msg;
+  entry.className = 'log-entry';
+  logDiv.appendChild(entry);
+  if (logDiv.childNodes.length > 6) logDiv.removeChild(logDiv.firstChild);
+  logDiv.scrollTop = logDiv.scrollHeight;
+}
+
+function damageNumber(c, amount, heal=false) {
+  const div = document.createElement('div');
+  div.textContent = amount;
+  div.className = 'damage';
+  if (heal) div.classList.add('heal');
+  c.dom.div.appendChild(div);
+  setTimeout(() => div.remove(), 1000);
+}
+
+function lineBetween(a,b) {
+  const rectA = a.dom.div.getBoundingClientRect();
+  const rectB = b.dom.div.getBoundingClientRect();
+  const svgRect = effectsSvg.getBoundingClientRect();
+  const line = document.createElementNS('http://www.w3.org/2000/svg','line');
+  line.setAttribute('x1', rectA.left + rectA.width/2 - svgRect.left);
+  line.setAttribute('y1', rectA.top + rectA.height/2 - svgRect.top);
+  line.setAttribute('x2', rectB.left + rectB.width/2 - svgRect.left);
+  line.setAttribute('y2', rectB.top + rectB.height/2 - svgRect.top);
+  line.classList.add('attack-line');
+  effectsSvg.appendChild(line);
+  setTimeout(() => line.remove(), 300);
+}
+
+function attack(attacker, target) {
+  return new Promise(resolve => {
+    attacker.dom.div.classList.add('active');
+    const dmg = rand(attacker.attack[0], attacker.attack[1]);
+    moveForward(attacker.dom.div, attacker.dom.div.parentElement === heroesDiv ? 20 : -20)
+    .then(() => {
+      lineBetween(attacker, target);
+      target.hp = Math.max(target.hp - dmg, 0);
+      updateChar(target);
+      damageNumber(target, dmg);
+      log(`${attacker.name} hits ${target.name} for ${dmg} dmg. ${target.name} ${target.hp}/${target.maxHp}`);
+      setTimeout(() => {
+        attacker.dom.div.classList.remove('active');
+        moveForward(attacker.dom.div, 0).then(resolve);
+      }, 300 / speed);
+    });
+  });
+}
+
+function heal(c) {
+  return new Promise(resolve => {
+    c.dom.div.classList.add('active');
+    const amt = rand(1,5);
+    c.hp = Math.min(c.hp + amt, c.maxHp);
+    updateChar(c);
+    damageNumber(c, amt, true);
+    log(`${c.name} heals for ${amt}. ${c.hp}/${c.maxHp}`);
+    setTimeout(() => {
+      c.dom.div.classList.remove('active');
+      resolve();
+    }, 300 / speed);
+  });
+}
+
+function rand(a,b) { return Math.floor(Math.random()*(b-a+1))+a; }
+
+function moveForward(elem, distance) {
+  return new Promise(res => {
+    elem.style.transform = `translateX(${distance}px)`;
+    setTimeout(res, 300 / speed);
+  });
+}
+
+async function gameLoop() {
+  updatePanels();
+  statusDiv.textContent = `Round ${round}`;
+  for (const [side, enemies] of [[heroes, monsters], [monsters, heroes]]) {
+    for (const actor of side) {
+      if (!actor.hp || !running) await waitWhilePaused();
+      if (actor.hp <= 0) continue;
+      const living = enemies.filter(e => e.hp > 0);
+      if (!living.length) return;
+      const target = living[Math.floor(Math.random() * living.length)];
+      if (Math.random() < 0.8) await attack(actor, target);
+      else await heal(actor);
+      updatePanels();
+      await delay(500 / speed);
+    }
+  }
+  round++;
+  if (heroes.every(h => h.hp <= 0)) statusDiv.textContent = 'Monsters win!';
+  else if (monsters.every(m => m.hp <= 0)) statusDiv.textContent = 'Heroes win!';
+  else setTimeout(gameLoop, 10);
+}
+
+function waitWhilePaused() {
+  return new Promise(r => {
+    (function check() {
+      if (running) r(); else setTimeout(check, 100);
+    })();
+  });
+}
+
+function delay(ms) { return new Promise(r => setTimeout(r, ms)); }
+
+function init() {
+  heroes.forEach(h => heroesDiv.appendChild(createCharElem(h)));
+  monsters.forEach(m => monstersDiv.appendChild(createCharElem(m)));
+  gameLoop();
+}
+init();
+

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Auto-Battler</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div id="top-bar">
+  <div id="title">Auto-Battler</div>
+  <div id="controls">
+    <button id="play-pause">Pause</button>
+    <button id="restart">Restart</button>
+    <label>Speed
+      <input type="range" id="speed" min="0.5" max="3" step="0.5" value="1">
+    </label>
+  </div>
+  <div id="status"></div>
+</div>
+<div id="battlefield">
+  <div id="heroes" class="side"></div>
+  <div id="divider"></div>
+  <div id="monsters" class="side"></div>
+  <svg id="effects"></svg>
+</div>
+<div id="panels">
+  <div id="hero-panel" class="panel"></div>
+  <div id="monster-panel" class="panel"></div>
+</div>
+<div id="log"></div>
+<script src="game.js"></script>
+</body>
+</html>
+

--- a/web/style.css
+++ b/web/style.css
@@ -1,0 +1,100 @@
+body {
+  font-family: sans-serif;
+  background: linear-gradient(#111, #333);
+  color: #fff;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+#top-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 16px;
+}
+#battlefield {
+  flex: 1;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.side {
+  flex: 1;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: center;
+}
+#divider {
+  width: 2px;
+  background: #555;
+  height: 60%;
+}
+.character {
+  text-align: center;
+  position: relative;
+}
+.character .icon {
+  font-size: 2rem;
+  display: block;
+  transition: transform 0.2s;
+}
+.hp-bar {
+  width: 50px;
+  height: 6px;
+  background: #555;
+  margin: 2px auto;
+  position: relative;
+}
+.hp-bar-inner {
+  background: #0f0;
+  height: 100%;
+}
+.damage {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  color: #f44;
+  font-weight: bold;
+  animation: float-up 1s forwards;
+}
+.damage.heal {
+  color: #4f4;
+}
+@keyframes float-up {
+  from { opacity: 1; top: -10px; }
+  to { opacity: 0; top: -30px; }
+}
+.character.active .icon {
+  transform: scale(1.2);
+}
+.attack-line {
+  stroke: #fff;
+  stroke-width: 2;
+}
+#log {
+  height: 120px;
+  overflow: hidden;
+  font-size: 14px;
+  padding: 4px 8px;
+  background: rgba(0,0,0,0.5);
+}
+.log-entry {
+  animation: log-move 0.3s ease-in-out forwards;
+}
+@keyframes log-move {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+.panel {
+  width: 50%;
+  padding: 4px;
+  font-size: 14px;
+  white-space: pre-line;
+}
+#panels {
+  display: flex;
+  background: rgba(0,0,0,0.5);
+}
+


### PR DESCRIPTION
## Summary
- build web-based auto-battler demo with hero and monster sides
- show controls for play, restart and speed with round indicator
- animate attacks, healing and log events in battle

## Testing
- `node --check web/game.js && echo "JS syntax OK"`
- `python -m py_compile auto_rpg.py && echo "Python compile OK"`


------
https://chatgpt.com/codex/tasks/task_e_68b39bf221888325822162bb9bffdd01