### PR TITLE
Add combat statuses and hero abilities UI

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -79,13 +79,13 @@ class Character:
         })
         events.extend(other.take_damage(dmg))
         if random.random() < 0.1 and other.is_alive():
-            other.poison = 2
+            other.poison = random.randint(1, 3)
             other.poison_turns = 3
             events.append({
                 "type": "status",
                 "status": "poison",
                 "target": other.name,
-                "amount": 2,
+                "amount": other.poison,
                 "turns": 3
             })
         return events
@@ -124,7 +124,11 @@ class Game:
         ]
         self.round = 1
         self.taunt_target = None
-        self.arena = random.choice(["grassy field", "stone arena", "dark dungeon"])
+        self.arena = random.choice([
+            "The fight takes place in an abandoned ruin.",
+            "A cool breeze sweeps across the battlefield.",
+            "Thunder rumbles in the distance." 
+        ])
         self._event_gen = self._events()
 
     def _char_info(self, c):

--- a/static/app.js
+++ b/static/app.js
@@ -2,27 +2,51 @@ const heroesEl = document.getElementById('heroes');
 const monstersEl = document.getElementById('monsters');
 const logEl = document.getElementById('log');
 const roundEl = document.getElementById('round');
+const initEl = document.getElementById('initiative');
+
 let timer = null;
 let speed = 1;
 const characters = {};
+let initiative = [];
+let fireball = null;
 
-function log(msg) {
+function log(msg, cls = '') {
   const div = document.createElement('div');
   div.textContent = msg;
+  if (cls) div.className = cls;
   logEl.appendChild(div);
   logEl.scrollTop = logEl.scrollHeight;
+}
+
+function showAbilityBanner(text = 'Special Ability!') {
+  const banner = document.createElement('div');
+  banner.className = 'ability-banner';
+  banner.textContent = text;
+  document.body.appendChild(banner);
+  setTimeout(() => banner.remove(), 1000);
+}
+
+function renderInitiative() {
+  initEl.innerHTML = '';
+  initiative.forEach((n, i) => {
+    const div = document.createElement('div');
+    div.className = 'turn' + (i === 0 ? ' active' : '');
+    div.textContent = characters[n].icon;
+    initEl.appendChild(div);
+  });
 }
 
 function setup(sideEl, chars) {
   sideEl.innerHTML = '';
   chars.forEach(c => {
-    characters[c.name] = c;
+    characters[c.name] = { ...c, statuses: {} };
     const div = document.createElement('div');
     div.className = 'char';
     div.id = 'char-' + c.name;
-    div.innerHTML = `<div class="icon">${c.icon}</div><div>${c.name}</div><div class="hp-bar"><div class="hp"></div></div>`;
+    div.innerHTML = `<div class="icon">${c.icon}</div><div>${c.name}</div><div class="hp-bar"><div class="hp"></div></div><div class="status-icons"></div>`;
     sideEl.appendChild(div);
     updateHp(c.name, c.hp);
+    updateStatuses(c.name);
   });
 }
 
@@ -36,33 +60,126 @@ function updateHp(name, hp) {
   }
 }
 
+function updateStatuses(name) {
+  const st = characters[name].statuses;
+  const div = document.querySelector(`#char-${name} .status-icons`);
+  let html = '';
+  if (st.poison) html += '<span class="poison">☠️</span>';
+  if (st.shield) html += '<span class="shield">🛡️</span>';
+  if (st.rage) html += '<span class="rage">🔥</span>';
+  if (st.taunt) html += '<span class="taunt">🛡️</span>';
+  div.innerHTML = html;
+  const charDiv = document.getElementById('char-' + name);
+  if (st.shield) charDiv.classList.add('has-shield'); else charDiv.classList.remove('has-shield');
+}
+
+function flash(name) {
+  const el = document.getElementById('char-' + name);
+  el.classList.add('flash');
+  setTimeout(() => el.classList.remove('flash'), 300);
+}
+
+function shiftInitiative(name) {
+  if (initiative[0] === name) {
+    initiative.shift();
+    const st = characters[name].statuses;
+    if (st.rage) {
+      st.rage--;
+      if (st.rage <= 0) delete st.rage;
+    }
+    updateStatuses(name);
+    renderInitiative();
+  }
+}
+
 function handleEvent(ev) {
   if (!ev) return;
   switch (ev.type) {
     case 'start':
       setup(heroesEl, ev.heroes);
       setup(monstersEl, ev.monsters);
-      log('Battle begins in ' + ev.arena);
+      log(ev.arena);
       break;
     case 'round':
       roundEl.textContent = ev.round;
       log('Round ' + ev.round);
+      initiative = ev.order.slice();
+      Object.keys(characters).forEach(n => { delete characters[n].statuses.taunt; updateStatuses(n); });
+      renderInitiative();
       break;
     case 'attack':
-      log(`${ev.attacker} hits ${ev.target} for ${ev.damage}${ev.crit ? ' (crit!)' : ''}`);
+      log(`${ev.attacker} hits ${ev.target} for ${ev.damage}${ev.crit ? ' (crit!)' : ''}`, 'log-damage');
+      if (fireball && fireball.actor === ev.attacker) {
+        flash(ev.target);
+        fireball.remaining--;
+        if (fireball.remaining <= 0) {
+          shiftInitiative(ev.attacker);
+          fireball = null;
+        }
+      } else {
+        shiftInitiative(ev.attacker);
+      }
       break;
     case 'damage':
       updateHp(ev.target, ev.hp);
+      if (ev.source === 'poison') {
+        log(`${ev.target} takes ${ev.amount} poison damage`, 'log-damage');
+        const st = characters[ev.target].statuses;
+        if (st.poison) {
+          st.poison--;
+          if (st.poison <= 0) delete st.poison;
+          updateStatuses(ev.target);
+        }
+      }
       break;
     case 'heal':
       updateHp(ev.actor, ev.hp);
-      log(`${ev.actor} heals ${ev.amount}`);
+      log(`${ev.actor} heals ${ev.amount}`, 'log-heal');
+      shiftInitiative(ev.actor);
       break;
-    case 'status':
-      log(`${ev.target || ev.actor} gains ${ev.status}`);
+    case 'status': {
+      const name = ev.target || ev.actor;
+      switch (ev.status) {
+        case 'poison':
+          characters[name].statuses.poison = ev.turns;
+          updateStatuses(name);
+          log(`${name} is poisoned`, 'log-damage');
+          break;
+        case 'shield':
+          characters[name].statuses.shield = ev.remaining;
+          updateStatuses(name);
+          log(`${name} gains a shield`, 'log-heal');
+          break;
+        case 'rage':
+          characters[name].statuses.rage = 3;
+          updateStatuses(name);
+          log(`${name} is enraged!`, 'log-damage');
+          break;
+        case 'taunt':
+          characters[ev.actor].statuses.taunt = 1;
+          updateStatuses(ev.actor);
+          log(`${ev.actor} uses Taunt!`);
+          showAbilityBanner();
+          shiftInitiative(ev.actor);
+          break;
+        case 'fireball':
+          log(`${ev.actor} casts Fireball!`, 'log-damage');
+          showAbilityBanner();
+          fireball = { actor: ev.actor, remaining: 2 };
+          break;
+      }
+      break;
+    }
+    case 'shield':
+      if (ev.remaining > 0) {
+        characters[ev.target].statuses.shield = ev.remaining;
+      } else {
+        delete characters[ev.target].statuses.shield;
+      }
+      updateStatuses(ev.target);
       break;
     case 'death':
-      log(`${ev.target} dies`);
+      log(`${ev.target} dies`, 'log-death');
       break;
     case 'end':
       log(`${ev.winner} win!`);
@@ -86,6 +203,8 @@ function start() {
   fetch('/start').then(r => r.json()).then(ev => {
     logEl.innerHTML = '';
     roundEl.textContent = '0';
+    initiative = [];
+    fireball = null;
     handleEvent(ev);
     resume();
   });

--- a/static/index.html
+++ b/static/index.html
@@ -22,6 +22,7 @@
         <div id="heroes" class="side"></div>
         <div id="monsters" class="side"></div>
     </div>
+    <div id="initiative"></div>
     <div id="log"></div>
     <script src="app.js"></script>
 </body>

--- a/static/style.css
+++ b/static/style.css
@@ -2,10 +2,22 @@ body { font-family: sans-serif; margin:0; background:#222; color:#eee; }
 #top-panel { background:#444; padding:10px; }
 #arena { display:flex; justify-content:space-between; margin:20px; }
 .side { width:45%; display:flex; flex-direction:column; align-items:center; }
-.char { text-align:center; margin:10px; }
+.char { text-align:center; margin:10px; position:relative; border:2px solid transparent; }
 .char .icon { font-size:64px; }
 .hp-bar { width:80px; height:10px; background:#555; margin-top:4px; }
 .hp { background:#0f0; height:100%; }
 .dead .icon { opacity:0.4; }
+.status-icons { height:20px; margin-top:4px; }
+.status-icons span { margin:0 2px; }
+.has-shield { border-color:#0ff; }
+#initiative { display:flex; justify-content:center; margin:10px; }
+#initiative .turn { font-size:32px; margin:0 4px; opacity:0.4; }
+#initiative .turn.active { opacity:1; }
 #log { height:150px; overflow:auto; border-top:1px solid #555; padding:10px; background:#111; font-size:14px; }
+.log-damage { color:#f33; }
+.log-heal { color:#3f3; }
+.log-death { color:#999; }
+.flash { animation:flash 0.3s; }
+@keyframes flash { from { background:rgba(255,0,0,0.5); } to { background:transparent; } }
+.ability-banner { position:fixed; top:30%; left:50%; transform:translate(-50%,-50%); background:#333; padding:20px; font-size:24px; border:2px solid #fff; }
 #banner { position:fixed; top:40%; left:50%; transform:translate(-50%,-50%); background:#333; padding:20px; font-size:24px; border:2px solid #fff; }


### PR DESCRIPTION
## Summary
- Display initiative order, status icons, and ability banners in the arena
- Colorize the combat log and flash Fireball targets
- Vary poison damage and arena flavor text

## Testing
- `python -m py_compile engine.py server.py`
- `node --check static/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68b3abb2ec7c83259079fc96edf2dd1e