### PR TITLE
Reset battle state on restart and guard against stale events

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,9 +1,11 @@
-from flask import Flask, jsonify
+from flask import Flask, jsonify, request
 from engine import Game
+import uuid
 
 app = Flask(__name__, static_folder='static', static_url_path='')
 
 game = None
+current_run_id = None
 
 @app.route('/')
 def index():
@@ -11,16 +13,22 @@ def index():
 
 @app.route('/start')
 def start():
-    global game
+    global game, current_run_id
     game = Game()
+    current_run_id = str(uuid.uuid4())
     ev = game.next_event()
+    ev['runId'] = current_run_id
     return jsonify(ev)
 
 @app.route('/next')
 def next_event():
     if not game:
         return jsonify(None)
+    if request.args.get('runId') != current_run_id:
+        return jsonify(None)
     ev = game.next_event()
+    if ev:
+        ev['runId'] = current_run_id
     return jsonify(ev)
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- Clear previous game state and remove victory banners before starting a new run
- Tag game events with a runId so stale responses are ignored
- Abort in-flight /next requests and reset UI controls on restart

## Testing
- `python -m py_compile server.py engine.py`
- `node --check static/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68b3afb4032c83258fc1279e9c7a1239