### PR TITLE
Fix destroy shrine mission AI

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -285,6 +285,10 @@ function handleEvent(ev) {
       showAbilityBanner(mtitle);
       log(mtitle);
       break;
+    case 'objective_target':
+      const objEl = document.getElementById('char-' + ev.id);
+      if (objEl) objEl.classList.add('objective');
+      break;
     case 'objective_progress':
       if (mission === 'capture_point') {
         missionData.progress = ev.progress;

--- a/static/style.css
+++ b/static/style.css
@@ -15,9 +15,11 @@ body { font-family: sans-serif; margin:0; background:#222; color:#eee; }
 .tile.obstacle { background:#555; }
 .tile.hazard_poison { background:#505; }
 .tile.shrine { background:#030; color:#0f0; }
+.tile.enemy_shrine { background:#400; }
 .char { text-align:center; position:absolute; border:2px solid transparent; transition:top 0.3s,left 0.3s; }
 .char.hero { border-color:#0ff; background-image:repeating-linear-gradient(45deg,rgba(255,255,255,0.1)0 2px,transparent 2px 4px); }
 .char.monster { border-color:#f60; background-image:repeating-linear-gradient(135deg,rgba(255,255,255,0.1)0 4px,transparent 4px 8px); }
+.char.objective { border-color:#f00; }
 .char .badge { position:absolute; top:0; left:0; font-size:12px; background:rgba(0,0,0,0.5); padding:0 2px; }
 .char .icon { font-size:64px; }
 .hp-bar { width:60px; height:10px; background:#555; margin-top:4px; }


### PR DESCRIPTION
## Summary
- Add combat-phase start and shrine objective targeting
- Treat shrine as blocking objective and adjust pathfinding
- Highlight shrine target in UI

## Testing
- `python -m py_compile engine.py`
- `node --check static/app.js`
- `python - <<'PY'
from engine import Game

g = Game(mission='destroy_shrine')
for _ in range(50):
    ev = g.next_event()
    if not ev: break
    print(ev.get('type'))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b43680dc1483258e3b63d778a20fdb